### PR TITLE
fixed shell logs

### DIFF
--- a/antibody.zsh
+++ b/antibody.zsh
@@ -4,7 +4,7 @@ mkdir -p "$HOME/.antibody" || true
 
 antibody() {
   while read bundle; do
-    source "$bundle"/*.plugin.zsh &
+    source "$bundle"/*.plugin.zsh 2&> /tmp/antibody-log
   done < <( ${ANTIBODY_BINARIES}/antibody $@ )
 }
 


### PR DESCRIPTION
Depending on the system, it might log stuff like:

```
6]  + done       source "$bundle"/*.plugin.zsh
[6] 1398
[6]  + done       source "$bundle"/*.plugin.zsh
[6] 1399
[8] 1400
[8]  + done       source "$bundle"/*.plugin.zsh
[8] 1404
[8]  + done       source "$bundle"/*.plugin.zsh
[7]  + done       source "$bundle"/*.plugin.zsh
[7] 1405
[8] 1406
[6]    done       source "$bundle"/*.plugin.zsh
[8]  + done       source "$bundle"/*.plugin.zsh
[5]    done       source "$bundle"/*.plugin.zsh
[7]  + done       source "$bundle"/*.plugin.zsh
[7] 1465
[7]  + done       source "$bundle"/*.plugin.zsh
[7] 1467
```

This somehow also made the entire thing crash.
Fixed.