### PR TITLE
Improved packaging and readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
-antibody
-antibody_*
+bin/
 *.tar.gz

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A faster and simpler version of antigen.
 > (zsh) plugins, called bundles. The concept is pretty much the same as
 > bundles in a typical vim+pathogen setup. Antigen is to zsh, what Vundle
 > is to vim."
-> 
+>
 > Read more: [Antigen](https://github.com/zsh-users/antigen).
 
 ### Why?
@@ -49,6 +49,9 @@ Running `antibody bundle` will already apply the bundle given bundle.
 - Download the [last release](https://github.com/caarlos0/antibody/releases/);
 - Uncompress it somewhere;
 - `source antibody.zsh`.
+
+> **Attention**: the `antibody` binary file should not be in your `$PATH`.
+> You only need to source the `antibody.zsh` file!
 
 Now, you can just `antibody bundle` stuff, e.g.,
 `antibody bundle Tarrasch/zsh-autoenv`. The repository will be cloned at

--- a/antibody.zsh
+++ b/antibody.zsh
@@ -5,7 +5,7 @@ mkdir -p "$HOME/.antibody" || true
 antibody() {
   while read bundle; do
     source "$bundle"/*.plugin.zsh 2&> /tmp/antibody-log
-  done < <( ${ANTIBODY_BINARIES}/antibody $@ )
+  done < <( ${ANTIBODY_BINARIES}/bin/antibody $@ )
 }
 
 _antibody() {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,14 +8,17 @@ go test -v -cover ./lib
 
 # go get github.com/mitchellh/gox
 # gox -build-toolchain
-gox -osarch="linux/amd64 darwin/amd64" ./...
+gox \
+  -output="./bin/{{.Dir}}_{{.OS}}_{{.Arch}}" \
+  -osarch="linux/amd64 darwin/amd64" \
+  ./...
 
 git tag "$RELEASE"
 git push origin "$RELEASE"
 
 LOG="$(git log --pretty=oneline --abbrev-commit "$CURRENT"..HEAD)"
 
-# go get github.com/aktau/github-release
+go get github.com/aktau/github-release
 github-release release \
   --user caarlos0 \
   --repo antibody \
@@ -34,7 +37,7 @@ for platform in Darwin Linux; do
   tar \
     --transform="s/_${platform_lower}_amd64//" \
     -cvzf "$filename" \
-    "antibody_${platform_lower}_amd64" antibody.zsh
+    "bin/antibody_${platform_lower}_amd64" antibody.zsh
   github-release upload \
     --user caarlos0 \
     --repo antibody \

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,24 +1,22 @@
 #!/bin/bash
 RELEASE="v$1"
 CURRENT="$(git tag | tail -n1)"
-echo "Creating release $1..."
 
-#go get golang.org/x/tools/cmd/cover
-go test -v -cover ./lib
-
+# echo "Installing needed tools..."
 # go get github.com/mitchellh/gox
 # gox -build-toolchain
+# go get github.com/aktau/github-release
+# go get golang.org/x/tools/cmd/cover
+
+echo "Creating release $1..."
+go test -v -cover ./lib
 gox \
   -output="./bin/{{.Dir}}_{{.OS}}_{{.Arch}}" \
   -osarch="linux/amd64 darwin/amd64" \
   ./...
-
 git tag "$RELEASE"
 git push origin "$RELEASE"
-
 LOG="$(git log --pretty=oneline --abbrev-commit "$CURRENT"..HEAD)"
-
-go get github.com/aktau/github-release
 github-release release \
   --user caarlos0 \
   --repo antibody \
@@ -26,11 +24,9 @@ github-release release \
   --name "$2" \
   --description "$LOG" \
   --pre-release
-
 if [ "$(uname -s)" = "Darwin" ]; then
   PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH"
 fi
-
 for platform in Darwin Linux; do
   filename="antibody-$RELEASE-$platform.tar.gz"
   platform_lower="$(echo $platform | tr '[:upper:]' '[:lower:]')"


### PR DESCRIPTION
Now, binaries are shipped in a `bin` folder inside the `.tar.gz` file.

Also, improved the README pointing out that the antibody binary should not be in `$PATH`.

Fixes #18 